### PR TITLE
Bugfixes for glm adjustment

### DIFF
--- a/R/Data.R
+++ b/R/Data.R
@@ -170,7 +170,7 @@ validate.RoboDataTTE <- function(data){
   # Add additional data attributes
   data$n <- nrow(df)
   data$k <- length(levels(data$treat))
-  data$treat_levels <- levels(data$treat) %>% as.numeric
+  data$treat_levels <- levels(data$treat)
 
   # Estimate treatment allocation proportion
   data$pie <- table(data$treat) %>%

--- a/R/summary.R
+++ b/R/summary.R
@@ -76,7 +76,9 @@ print.GLMModelResult <- function(x, ...){
     etype <- "g-computation-type"
   }
   if(is.character(x$settings$g_family)){
-    family <- get(x$settings$g_family)
+    family <- get(x$settings$g_family)()
+  } else if(is.function(x$settings$g_family)){
+    family <- (x$settings$g_family)()
   } else {
     family <- x$settings$g_family
   }
@@ -85,7 +87,7 @@ print.GLMModelResult <- function(x, ...){
     sprintf("Treatment group mean estimates using a %s estimator",
             etype),
     sprintf("\n  from a GLM working model of family %s and link %s",
-            family()$family, family()$link)
+            family$family, family$link)
   )
   k <- length(x$data$treat_levels)
   mat <- get.dmat(x$data, x$settings$adj_vars)

--- a/R/summary.R
+++ b/R/summary.R
@@ -75,12 +75,17 @@ print.GLMModelResult <- function(x, ...){
   } else {
     etype <- "g-computation-type"
   }
+  if(is.character(x$settings$g_family)){
+    family <- get(x$settings$g_family)
+  } else {
+    family <- x$settings$g_family
+  }
   output <- c(
     output,
     sprintf("Treatment group mean estimates using a %s estimator",
             etype),
-    sprintf("\n  from a GLM working model of family %s",
-            x$settings$g_family$family)
+    sprintf("\n  from a GLM working model of family %s and link %s",
+            family()$family, family()$link)
   )
   k <- length(x$data$treat_levels)
   mat <- get.dmat(x$data, x$settings$adj_vars)

--- a/tests/testthat/test-glm.R
+++ b/tests/testthat/test-glm.R
@@ -157,6 +157,73 @@ test_that("GLM -- no covariates except strata", {
   expect_equal(length(non$mod$coefficients), 4)
 })
 
+DATA3 <- DATA2
+DATA3$A <- sample(c(1, 2, 3), size=nrow(DATA3), replace=TRUE)
+DATA3$A <- as.factor(DATA3$A)
 
+# TEST MORE THAN TWO TREATMENT GROUPS
+test_that("GLM -- 3 treatment groups", {
+  res <- robincar_glm(
+    df=DATA3,
+    response_col="y",
+    treat_col="A",
+    car_scheme="biased-coin",
+    covariate_cols=c("x1"),
+    strata_cols=c("z1"),
+    covariate_to_include_strata=TRUE,
+    g_family=binomial(link="logit"),
+    g_accuracy=7,
+    adj_method="heterogeneous",
+    vcovHC="HC0")
+})
+
+n <- 2000
+DATA4 <- data.frame(
+  y=rbinom(n=n, prob=0.5, size=1),
+  TRT01P=sample(1:3, replace=TRUE, size=n),
+  BWTGR1=rbinom(n=n, prob=0.1, size=1)
+)
+DATA4$TRT01P <- factor(DATA4$TRT01P)
+# DATA4$TRT01P <- factor(DATA4$TRT01P,
+#                        levels=1:3,
+#                        labels=c("placebo", "trt1", "trt2"))
+
+test_that("GLM -- test g_family types in print function", {
+  # Test with character
+  res1 <- robincar_glm(
+    df=DATA4,
+    response_col="y",
+    treat_col="TRT01P",
+    car_scheme="simple",
+    covariate_cols=c("BWTGR1"),
+    g_family="binomial",
+    adj_method="homogeneous"
+  )
+  print(res1)
+  # Test with function
+  res2 <- robincar_glm(
+    df=DATA4,
+    response_col="y",
+    treat_col="TRT01P",
+    car_scheme="simple",
+    covariate_cols=c("BWTGR1"),
+    g_family=binomial,
+    adj_method="homogeneous"
+  )
+  print(res2)
+  # Test with object
+  res3 <- robincar_glm(
+    df=DATA4,
+    response_col="y",
+    treat_col="TRT01P",
+    car_scheme="simple",
+    covariate_cols=c("BWTGR1"),
+    g_family=binomial(link="logit"),
+    adj_method="homogeneous"
+  )
+  print(res3)
+  expect_equal(res1$result, res2$result)
+  expect_equal(res1$result, res3$result)
+})
 
 # CHECK DESIGN MATRIX


### PR DESCRIPTION
* Fixed issue where you could not pass e.g., `g_family="binomial"`. Now you can pass any of the following types of family arguments (using binomial as an example), and we test to make sure they produce equivalent results: "binomial", binomial, binomial(link="logit").
* Fixed issue that did not allow labeled treatment groups.