### PR TITLE
Updated variance calculation when Ya = 0

### DIFF
--- a/tests/testthat/test-glm-calibration.R
+++ b/tests/testthat/test-glm-calibration.R
@@ -52,8 +52,11 @@ test_that("test calibration", {
       names(calib_this_est) <- NULL
       names(calib_this_se) <- NULL
       expect_equal(calib_this_est, calib_that$estimation$estimate)
-      expect_equal(calib_this_se, calib_that$estimation$se)
-      expect_equal(calib_this_vc, calib_that_vc)
+      # NEW: variance will no longer be the same now that we have done
+      # the finite sample correction for the variance estimation
+      # when there are lots of 0's in the response vector
+      # expect_equal(calib_this_se, calib_that$estimation$se)
+      # expect_equal(calib_this_vc, calib_that_vc)
     }
   }
 })

--- a/tests/testthat/test-glm-legacy.R
+++ b/tests/testthat/test-glm-legacy.R
@@ -79,7 +79,10 @@ test_that("GLM legacy", {
               names(this_est) <- NULL
               names(this_se) <- NULL
               expect_equal(this_est, that$estimation$estimate)
-              expect_equal(this_se, that$estimation$se)
+              # NEW: variance will no longer be the same now that we have done
+              # the finite sample correction for the variance estimation
+              # when there are lots of 0's in the response vector
+              # expect_equal(this_se, that$estimation$se)
             }
           }
         }


### PR DESCRIPTION
Updated the variance calculation for $diag(Var(Y_a - \mu_a))$. Rather than calculating the variance of the residuals directly, we are now taking the diagonals of $Var(Y_a - \mu_a) = Var(Y_a) + Var(\mu_a) - 2Cov(Y_a, \mu_a)$ and estimating each term separately.