### PR TITLE
Updated variance estimator for covariate-adjusted hazard ratio

### DIFF
--- a/R/adjust-covhr.R
+++ b/R/adjust-covhr.R
@@ -65,9 +65,11 @@ adjust.CovHR <- function(model, data){
   score.adj <- function(theta) score.theta(theta, df=df_process) - cov_adjust
   thetaCLhat <- stats::uniroot(score.adj, interval=model$interval)$root
 
+  # Use thetaLhat rather than thetaCLhat below Both result in consistent
+  # variance estimators but using thetaLhat is expected behavior.
   df <- df %>% dplyr::mutate(
-    ssig_l = .data$event * exp(thetaCLhat) * .data$Y0 * .data$Y1 /
-      (exp(thetaCLhat) * .data$Y1 + .data$Y0)**2
+    ssig_l = .data$event * exp(thetaLhat) * .data$Y0 * .data$Y1 /
+      (exp(thetaLhat) * .data$Y1 + .data$Y0)**2
   )
 
   # Summarize by strata (if CL, then single strata)

--- a/tests/testthat/helpers-covhr.R
+++ b/tests/testthat/helpers-covhr.R
@@ -59,7 +59,8 @@ covariate_adjusted_logrank_estimation<-function(data.simu,p_trt){
   }
   theta_CL<-uniroot(score_CL,interval=c(-10,10))$root # get the adjusted estimator
 
-  sigma2_L<-exp(theta_CL)*sum(data.rev$delta*data.rev$Y0*data.rev$Y1/(exp(theta_CL)*data.rev$Y1+data.rev$Y0)^2)/n
+  # Modification for making consistent with current code for testing (theta_L in place of theta_CL)
+  sigma2_L<-exp(theta_L)*sum(data.rev$delta*data.rev$Y0*data.rev$Y1/(exp(theta_L)*data.rev$Y1+data.rev$Y0)^2)/n
   sigma2_CL<-sigma2_L-p_trt*(1-p_trt)*(beta1.Ohat+beta0.Ohat) %*% var(x.mat) %*% (beta1.Ohat+beta0.Ohat)
   var_est<-sigma2_CL/sigma2_L^2/n
   return(list(theta_L=theta_L,se.theta_L=sqrt(1/sigma2_L/n),
@@ -146,7 +147,8 @@ covariate_adjusted_stratified_logrank_estimation<-function(data.simu,p_trt){
     theta_CSL<-uniroot(score_CSL,interval=c(-10,10))$root # get the adjusted estimator
   }
   ### calculate variance ###
-  sigma2_SL<-exp(theta_CSL)*sum(data.rev$delta*data.rev$Y0*data.rev$Y1/(exp(theta_CSL)*data.rev$Y1+data.rev$Y0)^2)/n
+  # Modification for making consistent with current code for testing (theta_SL in place of theta_CSL)
+  sigma2_SL<-exp(theta_SL)*sum(data.rev$delta*data.rev$Y0*data.rev$Y1/(exp(theta_SL)*data.rev$Y1+data.rev$Y0)^2)/n
   sigma2_CSL<-sigma2_SL
   for(z in fz.n){
     pz<-length(which(data.rev$fz==z))/n


### PR DESCRIPTION
Updated variance estimator for covariate-adjusted hazard ratio so that it uses the un-adjusted theta estimate rather than the adjusted theta estimate. Both result in consistent variance estimators but using un-adjusted theta is the expected behavior for the user.