### PR TITLE
Fixed printing error for formula used with glm.nb

### DIFF
--- a/R/description-glm.R
+++ b/R/description-glm.R
@@ -6,6 +6,7 @@ descript.GLMModelResult <- function(x, ...){
   } else {
     etype <- "g-computation-type"
   }
+
   if(is.character(x$settings$g_family)){
     if(x$settings$g_family == "nb"){
       family <- "negative binomial with unknown dispersion"
@@ -20,11 +21,16 @@ descript.GLMModelResult <- function(x, ...){
 
   if(!is.null(x$data$formula)){
 
-    if(x$settings$g_family == "nb"){
-      form <- x$data$formula
+    if(is.character(x$settings$g_family)){
+      if(x$settings$g_family == "nb"){
+        form <- x$data$formula
+      } else {
+        form <- x$mod$formula
+      }
     } else {
       form <- x$mod$formula
     }
+
     output <- c(
       output,
       sprintf("Treatment group mean estimates from a GLM working model of family %s and link %s using formula: \n",

--- a/R/description-glm.R
+++ b/R/description-glm.R
@@ -20,7 +20,11 @@ descript.GLMModelResult <- function(x, ...){
 
   if(!is.null(x$data$formula)){
 
-    form <- x$mod$formula
+    if(x$settings$g_family == "nb"){
+      form <- x$data$formula
+    } else {
+      form <- x$mod$formula
+    }
     output <- c(
       output,
       sprintf("Treatment group mean estimates from a GLM working model of family %s and link %s using formula: \n",

--- a/tests/testthat/test-glm.R
+++ b/tests/testthat/test-glm.R
@@ -241,6 +241,21 @@ test_that("GLM full function -- NEGATIVE binomial, permuted block", {
     covariate_to_include_strata=TRUE)
   expect_equal(class(non), "GLMModelResult")
 
+  non
+
+  # Test with formula
+  non <- robincar_glm2(
+    df=DATA2,
+    response_col="y",
+    treat_col="A",
+    car_strata_cols=c("z1"),
+    formula="y ~ A + z1",
+    car_scheme="permuted-block",
+    g_family="nb",
+    g_accuracy=7)
+
+  non
+
 })
 
 test_that("GLM Settings", {


### PR DESCRIPTION
Issue #19 showed that with `robincar_glm` and `robincar_glm2`, if you printed a negative binomial (unknown dispersion parameter) robincar object where you had specified the model using a formula, it would given an error. This is because `glm.nb` stores information different than `glm`. I have added logic for this and tests to make sure it works.