### PR TITLE
Bugfix for contrast function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,11 @@
 and renamed `robincar_glm2` to `robincar_glm`. Same with `robincar_linear` and `robincar_linear2`. In effect,
 the older versions of `robincar_linear` and `robincar_glm` have been deprecated.
 
+## Bugfixes
+
+* Previously, the factor level order passed by the user for the treatment variable was ignored. We have fixed this,
+so all estimates will be presented in the order of treatment levels specified by user.
+
 # RobinCar 0.2.0
 
 ## Features

--- a/R/Data.R
+++ b/R/Data.R
@@ -170,7 +170,6 @@ validate.RoboDataTTE <- function(data, ref_arm, ...){
       # Include the covariates that will be needed for the formula
       # in a formula vector
       data[["formula"]] <- forms[[1]]
-      data[["formula_vars"]] <- df[forms[[2]]]
 
     } else if(grepl("col", att_name)){
 
@@ -200,13 +199,14 @@ validate.RoboDataTTE <- function(data, ref_arm, ...){
   data <- .df.toclass(df=df, classname=classname, ...)
 
   if(!is.null(data$treat)){
-    data$treat <- as.factor(as.vector(data$treat[[1]]))
+    data$treat <- data$treat[[1]]
+    if(!is.factor(data$treat)) data$treat <- as.factor(data$treat)
   }
   if(!is.null(data$response)){
-    data$response <- as.vector(data$response[[1]])
+    data$response <- data$response[[1]]
   }
   if(!is.null(data$event)){
-    data$event <- as.vector(data$event[[1]])
+    data$event <- data$event[[1]]
   }
   if(ncol(data$car_strata) == 0){
     data$car_strata <- NULL
@@ -227,6 +227,8 @@ validate.RoboDataTTE <- function(data, ref_arm, ...){
     }
   }
 
+  # Save original data frame
+  data$df <- df
 
   # Add additional data attributes
   data$n <- nrow(df)

--- a/R/adjust-glm.R
+++ b/R/adjust-glm.R
@@ -28,13 +28,11 @@ fitmod <- function(family, ...){
 adjust.GLMModel <- function(model, data, ...){
 
   # 1. Set up data frame
-  df <- data.frame(
-    treat=data$treat,
-    response=data$response
-  )
-  if(!is.null(data$formula_vars)){
-    df <- cbind(df, data$formula_vars)
-  }
+  df <- data$df
+  columns <- colnames(df)
+  columns[which(columns == data$treat_col)] <- "treat"
+  columns[which(columns == data$response_col)] <- "response"
+  df <- setNames(df, columns)
 
   # 2. Fit GLM working model
   glmod <- fitmod(

--- a/tests/testthat/test-contrast.R
+++ b/tests/testthat/test-contrast.R
@@ -1,0 +1,28 @@
+
+
+test_that("Test contrast function ordering", {
+
+  data <- RobinCar:::data_sim %>%
+    # recode A from 0 to "a", 1 to "b", 2 to "c"
+    mutate(A=factor(A, levels=0:2, labels=c("b", "c", "a")))
+
+  my.f<-function(x){
+    x[2]-x[1] # should be "c"-"b" based on the ordering
+  }
+
+  fit.anova <- robincar_linear(df = data,
+                               response_col="y",
+                               treat_col="A",
+                               car_scheme="simple",
+                               adj_method="ANOVA",
+                               contrast_h=my.f)
+
+  # Check levels are in the right order
+  lev <- fit.anova$main$result$treat
+  expect_equal(lev, c("b", "c", "a"))
+
+  # Check that the estimates are in correct order
+  anova <- mean(data$y[data$A == "c"]) - mean(data$y[data$A == "b"])
+  expect_equal(as.vector(fit.anova$contrast$result$estimate[1]), anova)
+
+})


### PR DESCRIPTION
Previously, we ignored (accidentally) the order of the treatment labels passed by the user. Now we're preserving their factor labeling. Added a test to ensure correct behavior.

In the process, I also realized that we could simplify some of the formula code a bit further and hopefully mitigate future bugs/issues, by using the original data frame (rather than a new one) in our call to `glm()`.