### PR TITLE
Added ordering for dplyr locale issue.

### DIFF
--- a/R/variance-linear.R
+++ b/R/variance-linear.R
@@ -12,9 +12,10 @@ vcov_sr_diag <- function(data, mod, residual=NULL){
   if(is.null(residual)){
     residual <- stats::residuals(mod)
   }
-
-  result <- mod$data %>%
-    dplyr::mutate(resid=residual) %>%
+  result <- dplyr::tibble(
+    resid=residual,
+    treat=data$treat
+  ) %>%
     dplyr::group_by(.data$treat) %>%
     dplyr::summarize(se=stats::sd(.data$resid), .groups="drop") %>%
     dplyr::mutate(se=.data$se*sqrt(1/data$pie))

--- a/tests/testthat/test-factor-ordering.R
+++ b/tests/testthat/test-factor-ordering.R
@@ -1,0 +1,55 @@
+library(MASS)
+library(dplyr)
+
+DATA <- RobinCar:::data_sim
+DATA$A <- as.factor(DATA$A)
+DATA$y_bin <- ifelse(DATA$y > 2, 1, 0)
+
+# Ensure that the naming/capitalization
+# of the treatment variable does not impact results.
+
+DATA <- DATA %>% mutate(
+  A2=paste0("TREAT", A),
+  A3=ifelse(A2 == "TREAT1", "treat1", A2)
+)
+
+# Doing DATA %>% group_by(A3) %>% summarize(n()) will
+# order the levels by c("TREAT0", "TREAT2", "treat1")
+#
+# whereas factor(DATA$A3) will order the levels
+# by c("TREAT0", "TREAT1", "TREAT2").
+
+test_that("GLM full function -- linear (ANOVA)", {
+
+  # The locale is actually the issue -- testthat
+  # automatically sets locale C but the issue only
+  # appears under locale != C. So here we set it to
+  # en_US.UTF-8.
+
+  original_locale <- Sys.getlocale("LC_COLLATE")
+  Sys.setlocale("LC_COLLATE", "en_US.UTF-8")
+
+  # English language ordering
+  langENG <- robincar_glm(
+    df=DATA,
+    response_col="y",
+    treat_col="A2",
+    car_scheme="simple",
+    formula="y ~ A2 + x1")
+
+  # C language ordering
+  langC <- robincar_glm(
+    df=DATA,
+    response_col="y",
+    treat_col="A3",
+    car_scheme="simple",
+    formula="y ~ A3 + x1")
+
+  expect_equal(langENG$result$estimate, langC$result$estimate)
+  expect_equal(langENG$varcov, langC$varcov)
+
+  # Reset the locale
+  Sys.setlocale("LC_COLLATE", original_locale)
+
+})
+

--- a/tests/testthat/test-factor-ordering.R
+++ b/tests/testthat/test-factor-ordering.R
@@ -46,7 +46,7 @@ test_that("GLM full function -- linear (ANOVA)", {
     formula="y ~ A3 + x1")
 
   expect_equal(langENG$result$estimate, langC$result$estimate)
-  expect_equal(langENG$varcov, langC$varcov)
+  expect_equal(c(langENG$varcov), c(langC$varcov))
 
   # Reset the locale
   Sys.setlocale("LC_COLLATE", original_locale)


### PR DESCRIPTION
In version 1.1.0 of dplyr, they switched to ordering `group_by` by the system locale (e.g., "English") to "C". This means that something like c("a", "b", "A", "B") would be reordered to c("A", "B", "a", "b"). This caused issues internally and produced incorrect results, when someone did not use a constant case (like "a" or "A") in their treatment variable naming.

The implemented fix uses the already factored variable, rather than a version of the variable that's not a factor. So `group_by` does not have to rely on a locale to figure out the ordering.

The tests for this have to intentionally set the locale to be English. This is because the C locale is automatically set for the testthat suite, meaning the test could pass, but the undesirable behavior could still occur when it's run outside of the testing suite.