### PR TITLE
Change how robincar_logrank, and robincar_covhr deal with ties

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Description: Performs robust estimation and inference when using covariate adjus
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Imports: 
     dplyr,
     magrittr,

--- a/R/adjust-logrank.R
+++ b/R/adjust-logrank.R
@@ -33,9 +33,9 @@ adjust.LogRank <- function(model, data, ...){
     dplyr::arrange(.data$car_strata)
 
   # Final quantities for the C(S)L statistic
-  U_CSL     <- mean(df$uu_cl)
-  var_CSL   <- sum(df$ssig_l, na.rm=TRUE) / data$n - sum(ss$var_adj) / data$n
-  se        <- sqrt(var_CSL / data$n)
+  U_CSL     <- sum(df$uu_cl) / data$n
+  var_CSL   <- (sum(df$ssig_l, na.rm=TRUE) - sum(ss$var_adj)) / data$n^2
+  se        <- sqrt(var_CSL)
   statistic <- U_CSL / se
 
   result <- list(

--- a/R/adjust-logrank.R
+++ b/R/adjust-logrank.R
@@ -18,7 +18,7 @@ adjust.LogRank <- function(model, data, ...){
     dplyr::mutate(
       uu_cl  = .data$trt1 * (.data$O.hat - .data$adjust1) -
                .data$trt0 * (.data$O.hat - .data$adjust0),
-      ssig_l = .data$event * .data$Y0 * .data$Y1 / .data$Y^2
+      ssig_l = .data$event * .data$Y0 * .data$Y1 * (.data$Y - .data$n.events) / .data$Y^2 / (.data$Y-1)
     )
 
   # Summarize by car_strata (if CL, then single car_strata)
@@ -34,7 +34,7 @@ adjust.LogRank <- function(model, data, ...){
 
   # Final quantities for the C(S)L statistic
   U_CSL     <- mean(df$uu_cl)
-  var_CSL   <- mean(df$ssig_l) - sum(ss$var_adj) / data$n
+  var_CSL   <- mean(df$ssig_l, na.rm=TRUE) - sum(ss$var_adj) / data$n
   se        <- sqrt(var_CSL / data$n)
   statistic <- U_CSL / se
 

--- a/R/adjust-logrank.R
+++ b/R/adjust-logrank.R
@@ -34,7 +34,7 @@ adjust.LogRank <- function(model, data, ...){
 
   # Final quantities for the C(S)L statistic
   U_CSL     <- mean(df$uu_cl)
-  var_CSL   <- mean(df$ssig_l, na.rm=TRUE) - sum(ss$var_adj) / data$n
+  var_CSL   <- sum(df$ssig_l, na.rm=TRUE) / data$n - sum(ss$var_adj) / data$n
   se        <- sqrt(var_CSL / data$n)
   statistic <- U_CSL / se
 

--- a/R/adjust-tte.R
+++ b/R/adjust-tte.R
@@ -55,20 +55,21 @@ process.tte.df <- function(df, ref_arm=NULL){
     ungroup() %>%
     group_by(.data$car_strata, .data$response) %>%
     mutate(
-      Y=first(Y),
-      Y1=first(Y1),
-      Y0=first(Y0),
-      n.events=sum(event)
+      Y=first(.data$Y),
+      Y1=first(.data$Y1),
+      Y0=first(.data$Y0),
+      n.events=sum(.data$event)
     ) %>%
     ungroup() %>%
+    group_by(.data$car_strata) %>%
     mutate(
-      cum.delta.Y0.over.Ysq=cumsum(Y0/Y^2*event),
-      cum.delta.Y1.over.Ysq=cumsum(Y1/Y^2*delta)
+      cum.delta.Y0.over.Ysq=cumsum(.data$Y0/.data$Y^2*.data$event),
+      cum.delta.Y1.over.Ysq=cumsum(.data$Y1/.data$Y^2*.data$event)
     ) %>%
     group_by(.data$car_strata, .data$response) %>%
     mutate(
-      cum.delta.Y0.over.Ysq=last(cum.delta.Y0.over.Ysq),
-      cum.delta.Y1.over.Ysq=last(cum.delta.Y1.over.Ysq)
+      cum.delta.Y0.over.Ysq=last(.data$cum.delta.Y0.over.Ysq),
+      cum.delta.Y1.over.Ysq=last(.data$cum.delta.Y1.over.Ysq)
     ) %>%
     ungroup()
 
@@ -83,12 +84,12 @@ get.ordered.data <- function(df, ref_arm){
     mutate(
       mu_t            = .data$Y1 / .data$Y,
 
-      O.hat1          = .data$delta * (.data$Y0/.data$Y) -
+      O.hat1          = .data$event * (.data$Y0/.data$Y) -
         .data$cum.delta.Y0.over.Ysq,
-      O.hat.0         = .data$delta * (.data$Y1/.data$Y) -
-        .data.cum.delta.Y1.over.Ysq,
-      O.hat           = (.data$trt1 == 1) * .data$O.hat1 +
-        (.data$trt0 == 1) * .data$O.hat0,
+      O.hat0          = .data$event * (.data$Y1/.data$Y) -
+        .data$cum.delta.Y1.over.Ysq,
+      O.hat           = .data$trt1 * .data$O.hat1 +
+        .data$trt0 * .data$O.hat0,
 
       s0_seq          = exp(.data$lin_pred),
       s1_seq          = .data$s0_seq * .data$trt1,
@@ -109,9 +110,6 @@ get.ordered.data <- function(df, ref_arm){
         .data$s0_seq * .data$cumsum_at_risk2,
 
       u_i             = .data$event * (.data$trt1 - .data$mu_t)
-    ) %>% mutate(
-      O.hat           = -.data$O.hat * (.data$trt0 == 1) +
-        .data$O.hat * (.data$trt1 == 1)
     ) %>% ungroup()
 
   return(df)

--- a/R/robincar-logrank.R
+++ b/R/robincar-logrank.R
@@ -5,12 +5,12 @@
 #' Note: Since RobinCar version 0.4.0, the variance of the test statistic has changed
 #' to better accommodate tied event times.
 #'
-#' The variance of the test statistic for the
-#' covariate-adjusted (possibly stratified) log-rank test is given by Ye, Shao, and Yi (2024) after
-#' equation (8) on page 700, \eqn{\hat{\sigma}_{\rm CSL}^2}, but with \eqn{\hat{\sigma}_{\rm SL}^2} replaced
-#' by the following estimator, which is the standard variance of the (stratified) logrank test:
+#' \eqn{\hat{\sigma}_{\rm CL}^2} and \eqn{\hat{\sigma}_{\rm CSL}^2} for the
+#' covariate-adjusted stratified log-rank test are given by Ye, Shao, and Yi (2024) after
+#' equation (8) on page 700, with \eqn{\hat{\sigma}_{\rm SL}^2} replaced
+#' by the following estimator, which is the standard denominator of the logrank test:
 #'
-#' \deqn{\sum_{j} \sum_{i} v_j(t_i)}
+#' \deqn{\frac1n \sum_{j} \sum_{i} v_j(t_i)}
 #' \deqn{v_j(t_i) = \frac{Y_{0,j}(t)Y_{1,j}(t)d_j(t)\left[Y_j(t) - d_j(t)\right]}{Y_j(t)^2\left[Y_j(t) - 1 \right]}}
 #' where \eqn{t_i} are strata-specific unique failure times, \eqn{d_j(t)} is the number of events at time \eqn{t} in strata \eqn{j},
 #' \eqn{Y_j(t)} is the number at risk within strata \eqn{j} at time \eqn{t},

--- a/R/robincar-logrank.R
+++ b/R/robincar-logrank.R
@@ -2,6 +2,23 @@
 #'
 #' Perform a robust covariate-adjusted logrank test ("CL") that can be stratified ("CSL") if desired.
 #'
+#' Note: Since RobinCar version 0.4.0, the variance of the test statistic has changed
+#' to better accommodate tied event times.
+#'
+#' The variance of the test statistic for the
+#' covariate-adjusted (possibly stratified) log-rank test is given by Ye, Shao, and Yi (2024) after
+#' equation (8) on page 700, \eqn{\hat{\sigma}_{\rm CSL}^2}, but with \eqn{\hat{\sigma}_{\rm SL}^2} replaced
+#' by the following estimator, which is the standard variance of the (stratified) logrank test:
+#'
+#' \deqn{\sum_{j} \sum_{i} v_j(t_i)}
+#' \deqn{v_j(t_i) = \frac{Y_{0,j}(t)Y_{1,j}(t)d_j(t)\left[Y_j(t) - d_j(t)\right]}{Y_j(t)^2\left[Y_j(t) - 1 \right]}}
+#' where \eqn{t_i} are strata-specific unique failure times, \eqn{d_j(t)} is the number of events at time \eqn{t} in strata \eqn{j},
+#' \eqn{Y_j(t)} is the number at risk within strata \eqn{j} at time \eqn{t},
+#' and \eqn{Y_{a,j}(t)} is the number at risk within strata \eqn{j} and treatment \eqn{a} at time \eqn{t}.
+#'
+#' Please see Ye, Shao, and Yi (2024)'s \link[=https://academic.oup.com/biomet/article/111/2/691/7232224?login=true]{"Covariate-adjusted log-rank test: guaranteed efficiency
+#' gain and universal applicability"} in \emph{Biometrika} for more details about \eqn{\hat{\sigma}_{\rm CSL}^2}.
+#'
 #' @param adj_method Adjustment method, one of "CL", "CSL"
 #' @param ... Additional arguments to `robincar_tte`
 #'

--- a/R/robincar-logrank.R
+++ b/R/robincar-logrank.R
@@ -16,8 +16,8 @@
 #' \eqn{Y_j(t)} is the number at risk within strata \eqn{j} at time \eqn{t},
 #' and \eqn{Y_{a,j}(t)} is the number at risk within strata \eqn{j} and treatment \eqn{a} at time \eqn{t}.
 #'
-#' Please see Ye, Shao, and Yi (2024)'s \link[=https://academic.oup.com/biomet/article/111/2/691/7232224?login=true]{"Covariate-adjusted log-rank test: guaranteed efficiency
-#' gain and universal applicability"} in \emph{Biometrika} for more details about \eqn{\hat{\sigma}_{\rm CSL}^2}.
+#' Please see Ye, Shao, and Yi (2024)'s "Covariate-adjusted log-rank test: guaranteed efficiency
+#' gain and universal applicability" in \emph{Biometrika} for more details about \eqn{\hat{\sigma}_{\rm CSL}^2}.
 #'
 #' @param adj_method Adjustment method, one of "CL", "CSL"
 #' @param ... Additional arguments to `robincar_tte`

--- a/man/robincar_logrank.Rd
+++ b/man/robincar_logrank.Rd
@@ -25,12 +25,12 @@ Perform a robust covariate-adjusted logrank test ("CL") that can be stratified (
 Note: Since RobinCar version 0.4.0, the variance of the test statistic has changed
 to better accommodate tied event times.
 
-The variance of the test statistic for the
-covariate-adjusted (possibly stratified) log-rank test is given by Ye, Shao, and Yi (2024) after
-equation (8) on page 700, \eqn{\hat{\sigma}_{\rm CSL}^2}, but with \eqn{\hat{\sigma}_{\rm SL}^2} replaced
-by the following estimator, which is the standard variance of the (stratified) logrank test:
+\eqn{\hat{\sigma}_{\rm CL}^2} and \eqn{\hat{\sigma}_{\rm CSL}^2} for the
+covariate-adjusted stratified log-rank test are given by Ye, Shao, and Yi (2024) after
+equation (8) on page 700, with \eqn{\hat{\sigma}_{\rm SL}^2} replaced
+by the following estimator, which is the standard denominator of the logrank test:
 
-\deqn{\sum_{j} \sum_{i} v_j(t_i)}
+\deqn{\frac1n \sum_{j} \sum_{i} v_j(t_i)}
 \deqn{v_j(t_i) = \frac{Y_{0,j}(t)Y_{1,j}(t)d_j(t)\left[Y_j(t) - d_j(t)\right]}{Y_j(t)^2\left[Y_j(t) - 1 \right]}}
 where \eqn{t_i} are strata-specific unique failure times, \eqn{d_j(t)} is the number of events at time \eqn{t} in strata \eqn{j},
 \eqn{Y_j(t)} is the number at risk within strata \eqn{j} at time \eqn{t},

--- a/man/robincar_logrank.Rd
+++ b/man/robincar_logrank.Rd
@@ -21,6 +21,24 @@ A result object with the following attributes:
 \description{
 Perform a robust covariate-adjusted logrank test ("CL") that can be stratified ("CSL") if desired.
 }
+\details{
+Note: Since RobinCar version 0.4.0, the variance of the test statistic has changed
+to better accommodate tied event times.
+
+The variance of the test statistic for the
+covariate-adjusted (possibly stratified) log-rank test is given by Ye, Shao, and Yi (2024) after
+equation (8) on page 700, \eqn{\hat{\sigma}_{\rm CSL}^2}, but with \eqn{\hat{\sigma}_{\rm SL}^2} replaced
+by the following estimator, which is the standard variance of the (stratified) logrank test:
+
+\deqn{\sum_{j} \sum_{i} v_j(t_i)}
+\deqn{v_j(t_i) = \frac{Y_{0,j}(t)Y_{1,j}(t)d_j(t)\left[Y_j(t) - d_j(t)\right]}{Y_j(t)^2\left[Y_j(t) - 1 \right]}}
+where \eqn{t_i} are strata-specific unique failure times, \eqn{d_j(t)} is the number of events at time \eqn{t} in strata \eqn{j},
+\eqn{Y_j(t)} is the number at risk within strata \eqn{j} at time \eqn{t},
+and \eqn{Y_{a,j}(t)} is the number at risk within strata \eqn{j} and treatment \eqn{a} at time \eqn{t}.
+
+Please see Ye, Shao, and Yi (2024)'s \link[=https://academic.oup.com/biomet/article/111/2/691/7232224?login=true]{"Covariate-adjusted log-rank test: guaranteed efficiency
+gain and universal applicability"} in \emph{Biometrika} for more details about \eqn{\hat{\sigma}_{\rm CSL}^2}.
+}
 \examples{
 library(magrittr)
 library(dplyr)

--- a/man/robincar_logrank.Rd
+++ b/man/robincar_logrank.Rd
@@ -36,8 +36,8 @@ where \eqn{t_i} are strata-specific unique failure times, \eqn{d_j(t)} is the nu
 \eqn{Y_j(t)} is the number at risk within strata \eqn{j} at time \eqn{t},
 and \eqn{Y_{a,j}(t)} is the number at risk within strata \eqn{j} and treatment \eqn{a} at time \eqn{t}.
 
-Please see Ye, Shao, and Yi (2024)'s \link[=https://academic.oup.com/biomet/article/111/2/691/7232224?login=true]{"Covariate-adjusted log-rank test: guaranteed efficiency
-gain and universal applicability"} in \emph{Biometrika} for more details about \eqn{\hat{\sigma}_{\rm CSL}^2}.
+Please see Ye, Shao, and Yi (2024)'s "Covariate-adjusted log-rank test: guaranteed efficiency
+gain and universal applicability" in \emph{Biometrika} for more details about \eqn{\hat{\sigma}_{\rm CSL}^2}.
 }
 \examples{
 library(magrittr)

--- a/tests/testthat/test-adjust-tte.R
+++ b/tests/testthat/test-adjust-tte.R
@@ -1,43 +1,5 @@
 library(dplyr)
 
-test_that("fix ties", {
-
-  n <- 10
-  data.simu <- data.frame(
-    id=1:n,
-    response=c(1,1,1,2,3,4,5,6,6,8),
-    Y1=1:n,
-    Y=n:1
-  ) %>%
-    mutate(Y0=Y-Y1)
-
-  data_fix_tie <- fix.ties(data.simu)
-
-  expect_true(all(diff(data_fix_tie$Y1[1:3])==0))
-  expect_true(all(diff(data_fix_tie$Y1[8:9])==0))
-  expect_true(all(diff(data_fix_tie$Y0[1:3])==0))
-  expect_true(all(diff(data_fix_tie$Y0[8:9])==0))
-
-})
-
-test_that("fix_tie() for no tie data",{
-
-  n <- 10
-  data.simu <- data.frame(
-    id=1:n,
-    response=1:n,
-    Y1=1:n,
-    Y=n:1) %>% mutate(Y0=Y-Y1)
-
-  data_fix_tie=fix.ties(data.simu)
-
-  expect_true(all(diff(data_fix_tie$Y1)!=0))
-  expect_true(all(diff(data_fix_tie$Y1)!=0))
-  expect_true(all(diff(data_fix_tie$Y0)!=0))
-  expect_true(all(diff(data_fix_tie$Y0)!=0))
-
-})
-
 test_that("data preprocessing", {
 
   set.seed(0)

--- a/tests/testthat/test-logrank-ties.R
+++ b/tests/testthat/test-logrank-ties.R
@@ -9,7 +9,9 @@ ting <- function(data){
     data.rev<- data.frame(data.simu.order,
                           Y=n:1,
                           Y1=cumsum(data.simu.order$I1[n:1])[n:1],
-                          Y0=cumsum(data.simu.order$I0[n:1])[n:1])
+                          Y0=cumsum(data.simu.order$I0[n:1])[n:1]
+    )
+
     data.rev <- data.rev %>% # handle ties, added by Ting
       group_by(t) %>%
       mutate(
@@ -25,21 +27,69 @@ ting <- function(data){
   wlogrank<-function(data.simu){
     n<-dim(data.simu)[1]
     data.rev<-data.sort(data.simu)
-    # T.seq<-data.rev$t
-    # T.rep<-c(0,T.seq)[1:n]
-    # T.diff<-T.seq-T.rep
-    # same.ind<-which(T.diff==0)
-    # n_col<-dim(data.rev)[2]
-    # for(ind in same.ind){
-    #   data.rev[ind,(n_col-2):n_col]<-data.rev[ind-1,(n_col-2):n_col]
-    # }
     S.alt<-sum(data.rev$delta*(data.rev$I1*data.rev$Y0-data.rev$I0*data.rev$Y1)/data.rev$Y)
     var.alt<-sum(data.rev$delta*data.rev$Y0*data.rev$Y1*(data.rev$Y-data.rev$n.events)/data.rev$Y^2/(data.rev$Y-1),na.rm=TRUE)
     res<-S.alt/sqrt(var.alt)
     return(list(S.alt=S.alt, res=res, var.alt=var.alt))
   }
 
-  return(wlogrank(data))
+  # covariate adjusted logrank proposed in Ye, Yi, Shao (2022)
+  covariate_adjusted_logrank <- function(data.simu){
+    p_trt<-mean(data.simu$I1)
+    n<-dim(data.simu)[1]
+    data.simu$fz<-factor(1) # for illustration purpose, just one stratum
+    data.rev<-data.sort(data.simu)
+
+    data.rev <- data.rev %>% mutate(cum.delta.Y0.over.Ysq=cumsum(Y0/Y^2*delta), # added by Ting to handle ties
+                                    cum.delta.Y1.over.Ysq=cumsum(Y1/Y^2*delta))
+    data.rev <- data.rev %>%
+      group_by(t) %>%
+      mutate(
+        cum.delta.Y0.over.Ysq=last(cum.delta.Y0.over.Ysq),
+        cum.delta.Y1.over.Ysq=last(cum.delta.Y1.over.Ysq)
+      ) %>%
+      ungroup()
+
+    mu_t<-data.rev$Y1/data.rev$Y
+    data.rev$O.hat1<-data.rev$delta*(data.rev$Y0/data.rev$Y)-
+      data.rev$cum.delta.Y0.over.Ysq
+    data.rev$O.hat0<-data.rev$delta*(data.rev$Y1/data.rev$Y)-
+      data.rev$cum.delta.Y1.over.Ysq
+    data.rev$O.hat<-data.rev$I1*data.rev$O.hat1+data.rev$I0*data.rev$O.hat0
+
+    sum(data.rev$I1*data.rev$O.hat -
+          data.rev$I0*data.rev$O.hat)/n
+
+    x.centered<-x.mat<-matrix(0,nrow=n,ncol=1)
+    beta1.Ohat<-0
+    beta0.Ohat<-0
+
+    ind.na<-which(is.na(beta1.Ohat))
+    if(length(ind.na)==0){
+      U_CL<-sum(data.rev$I1*(data.rev$O.hat-t((x.centered)%*% beta1.Ohat )) -
+                  data.rev$I0*(data.rev$O.hat-t((x.centered)%*% beta0.Ohat)))/n
+    }else{
+      warning("Removing model variables that are linearly dependent with the stratification variables.")
+      x.mat<-x.mat[,-ind.na,drop=FALSE]
+      x.centered<-x.centered[,-ind.na,drop=FALSE]
+      beta1.Ohat<-beta1.Ohat[-ind.na]
+      beta0.Ohat<-beta0.Ohat[-ind.na]
+      U_CL<-sum(data.rev$I1*(data.rev$O.hat-t((x.centered)%*% beta1.Ohat )) -
+                  data.rev$I0*(data.rev$O.hat-t((x.centered)%*% beta0.Ohat)))/n
+    }
+
+    score_logrank_anhecova_var<-function(data.rev,p_trt,fit1.Ohat,fit0.Ohat,beta1.Ohat,beta0.Ohat){
+      my.var.null<-(wlogrank(data.simu)$var.alt/n -
+                      # added by Ting to handle ties, uses log-rank variance estimator - variance reduction term
+                      p_trt*(1-p_trt)*(beta1.Ohat+beta0.Ohat) %*% var(x.mat) %*% (beta1.Ohat+beta0.Ohat) )/n
+      return(list(my.var.null=my.var.null))
+    }
+    tmp<-score_logrank_anhecova_var(data.rev,p_trt,fit1.Ohat,fit0.Ohat,beta1.Ohat,beta0.Ohat)
+    se.null<-sqrt(tmp$my.var.null)
+    return(list(U_CL=U_CL, se=se.null, res=U_CL/se.null))
+  }
+
+  return(covariate_adjusted_logrank(data))
 
 }
 
@@ -71,7 +121,7 @@ test_that("Logrank ovarian", {
   data$I1 <- DATA$rx - 1
   data$I0 <- 1 - data$I1
 
-  tingres <- (2 * pnorm(abs(ting(data)$res), lower.tail = F))
+  tingres <- c(2 * pnorm(abs(ting(data)$res), lower.tail = F))
 
   expect_equal(RC1res, lr_p)
   expect_equal(RC1res, tingres)
@@ -82,7 +132,7 @@ test_that("Logrank Ovarian with ties", {
 
   # Artificially create ties -----------------------------------
   # ------------------------------------------------------------
-
+  # ------------------------------------------------------------
   DATA2 <- DATA
 
   DATA2$tte[3:5] <- DATA2$tte[3]
@@ -111,7 +161,7 @@ test_that("Logrank Ovarian with ties", {
   data$I1 <- DATA2$rx - 1
   data$I0 <- 1 - data$I1
 
-  tingres <- (2 * pnorm(abs(ting(data)$res), lower.tail = F))
+  tingres <- c(2 * pnorm(abs(ting(data)$res), lower.tail = F))
 
   expect_equal(RC1res, lr_p)
   expect_equal(RC1res, tingres)

--- a/tests/testthat/test-logrank-ties.R
+++ b/tests/testthat/test-logrank-ties.R
@@ -1,0 +1,119 @@
+library(survival)
+library(dplyr)
+
+ting <- function(data){
+
+  data.sort<-function(data.simu){
+    n<-dim(data.simu)[1]
+    data.simu.order<- data.simu[order(data.simu$t),]
+    data.rev<- data.frame(data.simu.order,
+                          Y=n:1,
+                          Y1=cumsum(data.simu.order$I1[n:1])[n:1],
+                          Y0=cumsum(data.simu.order$I0[n:1])[n:1])
+    data.rev <- data.rev %>% # handle ties, added by Ting
+      group_by(t) %>%
+      mutate(
+        Y = first(Y),
+        Y1 = first(Y1),
+        Y0 = first(Y0),
+        n.events= sum(delta)
+      ) %>%
+      ungroup()
+    return(data.rev)
+  }
+
+  wlogrank<-function(data.simu){
+    n<-dim(data.simu)[1]
+    data.rev<-data.sort(data.simu)
+    # T.seq<-data.rev$t
+    # T.rep<-c(0,T.seq)[1:n]
+    # T.diff<-T.seq-T.rep
+    # same.ind<-which(T.diff==0)
+    # n_col<-dim(data.rev)[2]
+    # for(ind in same.ind){
+    #   data.rev[ind,(n_col-2):n_col]<-data.rev[ind-1,(n_col-2):n_col]
+    # }
+    S.alt<-sum(data.rev$delta*(data.rev$I1*data.rev$Y0-data.rev$I0*data.rev$Y1)/data.rev$Y)
+    var.alt<-sum(data.rev$delta*data.rev$Y0*data.rev$Y1*(data.rev$Y-data.rev$n.events)/data.rev$Y^2/(data.rev$Y-1),na.rm=TRUE)
+    res<-S.alt/sqrt(var.alt)
+    return(list(S.alt=S.alt, res=res, var.alt=var.alt))
+  }
+
+  return(wlogrank(data))
+
+}
+
+DATA <- ovarian %>%
+  rename(tte = futime, obs = fustat) %>%
+  arrange(tte)
+
+test_that("Logrank ovarian", {
+
+  # (1) Survdiff function
+  lr <- survdiff(Surv(tte, obs) ~ rx, data = DATA)
+  lr_p <- lr$pvalue
+  lr_num <- lr$obs[1] - lr$exp[1]
+  lr_var <- lr$var[1, 1] / nrow(DATA)
+
+  RC1 <- robincar_logrank(
+    adj_method = "CL",
+    df = DATA,
+    treat_col = "rx",
+    p_trt = 0.5,
+    ref_arm = 1,
+    response_col = "tte",
+    event_col = "obs"
+  )
+  RC1res <- (2 * pnorm(abs(RC1$result$statistic), lower.tail = F))
+
+  data <- DATA %>% select(t = tte)
+  data$delta <- 1*(DATA$obs==T)
+  data$I1 <- DATA$rx - 1
+  data$I0 <- 1 - data$I1
+
+  tingres <- (2 * pnorm(abs(ting(data)$res), lower.tail = F))
+
+  expect_equal(RC1res, lr_p)
+  expect_equal(RC1res, tingres)
+
+})
+
+test_that("Logrank Ovarian with ties", {
+
+  # Artificially create ties -----------------------------------
+  # ------------------------------------------------------------
+
+  DATA2 <- DATA
+
+  DATA2$tte[3:5] <- DATA2$tte[3]
+  DATA2$tte[10:12] <- DATA2$tte[10]
+  DATA2$tte[19:21] <- DATA2$tte[19]
+
+  # (1) Survdiff function
+  lr <- survdiff(Surv(tte, obs) ~ rx, data = DATA2)
+  lr_p <- lr$pvalue
+  lr_num <- lr$obs[1] - lr$exp[1]
+  lr_var <- lr$var[1, 1] / nrow(DATA)
+
+  RC1 <- robincar_logrank(
+    adj_method = "CL",
+    df = DATA2,
+    treat_col = "rx",
+    p_trt = 0.5,
+    ref_arm = 1,
+    response_col = "tte",
+    event_col = "obs"
+  )
+  RC1res <- (2 * pnorm(abs(RC1$result$statistic), lower.tail = F))
+
+  data <- DATA2 %>% select(t = tte)
+  data$delta <- 1*(DATA2$obs==T)
+  data$I1 <- DATA2$rx - 1
+  data$I0 <- 1 - data$I1
+
+  tingres <- (2 * pnorm(abs(ting(data)$res), lower.tail = F))
+
+  expect_equal(RC1res, lr_p)
+  expect_equal(RC1res, tingres)
+
+})


### PR DESCRIPTION
This pull request changes how `robincar_logrank` and `robincar_covhr` account for potential tied event times (within strata). We make sure that the results are still the same as they were before when there are no ties (for logrank and covhr), and we also add a test script to check that in the cases without covariate adjustment we get the same result as standard R functions with and without ties.