### PR TITLE
Added log ratio and log odds ratio contrasts

### DIFF
--- a/tests/testthat/test-contrast.R
+++ b/tests/testthat/test-contrast.R
@@ -26,3 +26,93 @@ test_that("Test contrast function ordering", {
   expect_equal(as.vector(fit.anova$contrast$result$estimate[1]), anova)
 
 })
+
+test_that("Test warnings for ratio and odds ratio functions", {
+
+  data <- RobinCar:::data_sim %>%
+    # recode A from 0 to "a", 1 to "b", 2 to "c"
+    mutate(A=factor(A, levels=0:2, labels=c("a", "b", "c"))) %>%
+    mutate(y_bin=ifelse(y > mean(y), 1, 0)) # create binary outcome
+
+  warning_txt <- "Using a ratio or odds ratio is not recommended.
+            Consider using log_ratio or log_odds_ratio for better
+            performance of the variance estimator."
+
+  # Test for linear model with ratio
+  expect_warning(
+    fit <- robincar_glm(
+      df=data,
+      response_col="y_bin",
+      treat_col="A",
+      formula= y_bin ~ A,
+      contrast_h="odds_ratio"
+    ),
+    warning_txt
+  )
+
+  # Test for linear model with ratio
+  expect_warning(
+    fit <- robincar_glm(
+      df=data,
+      response_col="y",
+      treat_col="A",
+      formula= y ~ A,
+      contrast_h="ratio"
+    ),
+    warning_txt
+  )
+
+})
+
+
+
+test_that("Test warnings for contrast functions that are not probabilities", {
+  # We want these to give warnings when someone
+  # specifies that they want a log odds ratio.
+
+  data <- RobinCar:::data_sim %>%
+    # recode A from 0 to "a", 1 to "b", 2 to "c"
+    mutate(A=factor(A, levels=0:2, labels=c("a", "b", "c"))) %>%
+    mutate(y_bin=ifelse(y > mean(y), 1, 0)) # create binary outcome
+
+  # Test for linear model with ratio
+  expect_warning(
+    fit <- robincar_glm(
+      df=data,
+      response_col="y",
+      treat_col="A",
+      formula= y ~ A,
+      contrast_h="log_odds_ratio"
+    ),
+    "Estimates are not between 0 and 1: are you sure you want an odds ratio?"
+  )
+
+})
+
+test_that("Compare log odds ratio SEs to GLM", {
+  # We want these to give warnings when someone
+  # specifies that they want a log odds ratio.
+
+  data <- RobinCar:::data_sim %>%
+    # recode A from 0 to "a", 1 to "b", 2 to "c"
+    mutate(A=factor(A, levels=0:2, labels=c("a", "b", "c"))) %>%
+    mutate(y_bin=ifelse(y > mean(y), 1, 0)) # create binary outcome
+
+  # Test for linear model with ratio
+  fit <- robincar_glm(
+    df=data,
+    response_col="y_bin",
+    treat_col="A",
+    formula= y_bin ~ A,
+    contrast_h="log_odds_ratio"
+  )
+
+  or <- with(data, glm(y_bin ~ A, family=binomial(link="logit")))
+
+  # Check that log odds ratios match
+  expect_equal(
+    unname(or$coefficients[2:3]),
+    unname(fit$contrast$result$estimate), tolerance=1e-6)
+
+})
+


### PR DESCRIPTION
- Added `log_ratio`, `log_odds_ratio`, and `odds_ratio` as options for the built-in contrasts.
- Give a warning if someone uses `odds_ratio` or `ratio` saying they should use the log options instead because they give better performance with variance estimation.
- Give a warning if someone requests `odds_ratio` or `log_odds_ratio` and their estimates are outside of the 0-1 range since this would mean they probably didn't want something on the odds scale, since they clearly don't have a probability.
- Added tests to check the above behavior.